### PR TITLE
Update dependencies and version constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 .php_cs.cache
 build
 composer.lock
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,27 +17,20 @@ matrix:
         # Minimum supported dependencies with the latest and oldest PHP version
         - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-        - php: 5.6
+        - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
 
         # Test the latest stable release
-        - php: 5.6
-        - php: 7.0
-          env: SYMFONY_PHPUNIT_VERSION="6.5"
-        - php: 7.1
-          env: SYMFONY_PHPUNIT_VERSION="6.5"
-        - php: 7.2
+        - php: 7.4
           env: COVERAGE=true CHECK_CS=true PHPUNIT_FLAGS="-v --coverage-clover=build/coverage.xml"
 
         # Test LTS versions. This makes sure we do not use Symfony packages with version greater
         # than 2 or 3 respectively. Read more at https://github.com/symfony/lts
-        - php: 7.2
-          env: SYMFONY_VERSION="2.8"
-        - php: 7.2
+        - php: 7.4
           env: SYMFONY_VERSION="3.4"
 
         # Latest commit to master
-        - php: 7.2
+        - php: 7.4
           env: STABILITY="dev"
 
     allow_failures:
@@ -51,9 +44,7 @@ before_install:
     - if [ -v "$SYMFONY_VERSION" ]; then composer config extra.symfony.require "${SYMFONY_VERSION}"; fi;
 
 install:
-    # For obscur reason, the PHP 5.6 with lowest dependencies is very long to execute, timeout has been raised
-    # to ensure stage is finished before timeout
-    - COMPOSER_MEMORY_LIMIT=-1 travis_wait 60 travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
+    - COMPOSER_MEMORY_LIMIT=-1 composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
     - ./vendor/bin/simple-phpunit install
 
 script:

--- a/Extractor/JsFileExtractor.php
+++ b/Extractor/JsFileExtractor.php
@@ -40,7 +40,7 @@ final class JsFileExtractor implements FileExtractor
         $this->extractor = $extractor ?: new JsTranslationExtractor();
     }
 
-    public function getSourceLocations(SplFileInfo $file, SourceCollection $collection)
+    public function getSourceLocations(SplFileInfo $file, SourceCollection $collection): void
     {
         $realPath = $file->getRealPath();
         $translations = $this->findTranslations($file);
@@ -51,19 +51,13 @@ final class JsFileExtractor implements FileExtractor
         }
     }
 
-    /**
-     * @return TranslationCollection
-     */
-    public function findTranslations(SplFileInfo $file)
+    public function supportsExtension(string $extension): bool
     {
-        return $this->extractor->extract($file->getContents(), new TranslationCollection());
+        return $this->type === $extension;
     }
 
-    /**
-     * @return string the file type
-     */
-    public function getType()
+    private function findTranslations(SplFileInfo $file): TranslationCollection
     {
-        return $this->type;
+        return $this->extractor->extract($file->getContents(), new TranslationCollection());
     }
 }

--- a/Tests/DependencyInjection/CoffreoPHPTranslationJsExtractorExtensionTest.php
+++ b/Tests/DependencyInjection/CoffreoPHPTranslationJsExtractorExtensionTest.php
@@ -9,16 +9,16 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 class CoffreoPHPTranslationJsExtractorExtensionTest extends AbstractExtensionTestCase
 {
     /**
-     * @return array|\Symfony\Component\DependencyInjection\Extension\ExtensionInterface[]
+     * @return \Symfony\Component\DependencyInjection\Extension\ExtensionInterface[]
      */
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new CoffreoPHPTranslationJsExtractorExtension(),
         ];
     }
 
-    public function getHandledTypes()
+    public function getHandledTypes(): array
     {
         return [
             ['js'],

--- a/Tests/Extractor/JsFileExtractorTest.php
+++ b/Tests/Extractor/JsFileExtractorTest.php
@@ -41,7 +41,6 @@ class JsFileExtractorTest extends TestCase
             ->willReturn($collectionStub);
 
         $extractor = new JsFileExtractor('type', $baseExtractorMock);
-        $this->assertEquals('type', $extractor->getType());
         $file = \realpath(__DIR__.'/../Resources/file');
 
         $collection = new SourceCollection();

--- a/composer.json
+++ b/composer.json
@@ -27,17 +27,16 @@
         "cs": "vendor/bin/php-cs-fixer fix --diff --verbose"
     },
     "require": {
-        "php": "^5.6 || ^7.0",
-        "php-translation/extractor": "^1.7",
-        "symfony/finder": "^2.7 || ^3.0 || ^4.0",
-        "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0",
-        "php-translation/symfony-bundle": "^0.8",
+        "php": "^7.2",
+        "php-translation/extractor": "^2.0.2",
+        "symfony/framework-bundle": "^3.0 || ^4.3 || ^5.0",
+        "php-translation/symfony-bundle": ">=0.9.0 <1.0.0",
         "coffreo/js-translation-extractor": "^0.1"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^3.4 || ^4.0",
         "coffreo/php-cs-fixer-config": "^2.2",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.2 || ^2.3 || ^3.1"
+        "matthiasnoback/symfony-dependency-injection-test": "^4.2"
     },
     "autoload": {
         "psr-4": {
@@ -48,8 +47,5 @@
         "psr-4": {
             "Coffreo\\PHPTranslationJsExtractorBundle\\Tests\\": "tests/"
         }
-    },
-    "conflict": {
-        "matthiasnoback/symfony-dependency-injection-test": "^4.0"
     }
 }


### PR DESCRIPTION
Loosened the constraint for `php-translation/symfony-bundle` as the [caret version range](https://getcomposer.org/doc/articles/versions.md#caret-version-range-) handles 0.x.x specially.