### PR TITLE
Add support for Symfony 6

### DIFF
--- a/DependencyInjection/CoffreoPHPTranslationJsExtractorExtension.php
+++ b/DependencyInjection/CoffreoPHPTranslationJsExtractorExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class CoffreoPHPTranslationJsExtractorExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
         $loader->load('services.yml');

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "php-translation/extractor": "^2.0.2",
-        "symfony/framework-bundle": "^3.0 || ^4.3 || ^5.0",
+        "symfony/framework-bundle": "^3.0 || ^4.3 || ^5.0 || ^6.0",
         "php-translation/symfony-bundle": ">=0.9.0 <1.0.0",
         "coffreo/js-translation-extractor": "^0.3"
     },


### PR DESCRIPTION
Not much reasoning to be added, but I see no reason why wouldn't this package support Symfony 6. Test seem to return green after updating the required Symfony packages to version 6.

```
vendor/bin/simple-phpunit --coverage-text --coverage-html=build/coverage
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

Warning:       No code coverage driver available
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing 
...                                                                 3 / 3 (100%)

Time: 00:00.324, Memory: 12.00 MB

OK (3 tests, 4 assertions)
```
